### PR TITLE
Make *_qc variables optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: false
 
 env:
     - CONDA="python=2.7"
-    - CONDA="python=3.4"
     - CONDA="python=3.5"
+    - CONDA="python=3.6"
 
 before_install:
     - wget http://bit.ly/miniconda -O miniconda.sh

--- a/cc_plugin_glider/glider_dac.py
+++ b/cc_plugin_glider/glider_dac.py
@@ -414,7 +414,7 @@ class GliderCheck(BaseNCCheck):
         '''
 
         level = BaseCheck.HIGH
-        out_of = 16
+        out_of = 7
         score = 0
         messages = []
 
@@ -431,12 +431,15 @@ class GliderCheck(BaseNCCheck):
             msg = 'Invalid variable type for time, it should be float64'
             messages.append(msg)
 
-        test = dataset.variables['time'].ancillary_variables == 'time_qc'
-        score += int(test)
-        if not test:
-            msg = ('Invalid ancillary_variables attribute for time, '
-                   'should be "time_qc"')
-            messages.append(msg)
+        if hasattr(dataset.variables['time'], 'ancillary_variables'):
+            out_of += 1
+            acv = dataset.variables['time'].ancillary_variables
+            test = acv in dataset.variables
+            score += int(test)
+            if not test:
+                msg = ('Invalid ancillary_variables attribute for time, '
+                       '{} is not a variable'.format(acv))
+                messages.append(msg)
 
         test = dataset.variables['time'].calendar == 'gregorian'
         score += int(test)
@@ -463,29 +466,6 @@ class GliderCheck(BaseNCCheck):
         score += int(test)
         if not test:
             messages.append('No units defined for time')
-
-        test = 'time_qc' in dataset.variables
-        score += int(test)
-        if not test:
-            messages.append('time_qc is not defined')
-            return self.make_result(level, score, out_of,
-                                    'Time Series Variable', messages)
-
-        required_time_qc_attributes = [
-            '_FillValue',
-            'flag_meanings',
-            'flag_values',
-            'long_name',
-            'standard_name',
-            'valid_max',
-            'valid_min'
-        ]
-        for attribute in required_time_qc_attributes:
-            test = hasattr(dataset.variables['time_qc'], attribute)
-            score += int(test)
-            if not test:
-                messages.append('%s attribute is required for time_qc' %
-                                attribute)
 
         return self.make_result(level, score, out_of,
                                 'Time Series Variable', messages)

--- a/cc_plugin_glider/glider_dac.py
+++ b/cc_plugin_glider/glider_dac.py
@@ -145,23 +145,24 @@ class GliderCheck(BaseNCCheck):
         '''
         Verifies the dataset has all the required QC variables
         '''
-        required_variables = [
-            'time_qc',
-            'lat_qc',
-            'lon_qc',
-            'pressure_qc',
-            'depth_qc',
-            'temperature_qc',
-            'conductivity_qc',
-            'density_qc',
-            'profile_time_qc',
-            'profile_lat_qc',
-            'profile_lon_qc',
-            'time_uv_qc',
-            'lat_uv_qc',
-            'lon_uv_qc',
-            'u_qc',
-            'v_qc'
+        test_ctx = TestCtx(BaseCheck.MEDIUM, 'QC Variables')
+        qc_variables = [
+            'time',
+            'lat',
+            'lon',
+            'pressure',
+            'depth',
+            'temperature',
+            'conductivity',
+            'density',
+            'profile_time',
+            'profile_lat',
+            'profile_lon',
+            'time_uv',
+            'lat_uv',
+            'lon_uv',
+            'u',
+            'v'
         ]
 
         required_attributes = [
@@ -172,24 +173,22 @@ class GliderCheck(BaseNCCheck):
             'valid_max',
             'valid_min'
         ]
-        level = BaseCheck.MEDIUM
-        out_of = len(required_variables)
-        score = 0
-        messages = []
-        for variable in required_variables:
-            test = variable in dataset.variables
-            if not test:
-                messages.append("%s is a required qc variable" % variable)
+        for variable in qc_variables:
+            qc_var = '{}_qc'.format(variable)
+
+            # QC varibles are no longer required
+            if qc_var not in dataset.variables:
                 continue
+
             for field in required_attributes:
-                if not hasattr(dataset.variables[variable], field):
-                    messages.append('%s is missing attribute %s' %
-                                    (variable, field))
-                    test = False
-                    break
-            score += int(test)
-        return self.make_result(level, score, out_of,
-                                'Required QC Variables', messages)
+                test = hasattr(dataset.variables[qc_var], field)
+                test_ctx.assert_true(test,
+                                     'variable {} must have a {} attribute'.format(qc_var, field))
+
+        if test_ctx.out_of == 0:
+            return None
+
+        return test_ctx.to_result()
 
     def check_global_attributes(self, dataset):
         '''
@@ -989,4 +988,3 @@ class GliderCheck(BaseNCCheck):
                              "Longitude's valid_min and valid_max are [-90, 90], it's likey this "
                              "was a mistake")
         return test_ctx.to_result()
-

--- a/cc_plugin_glider/tests/data/gliders/bad_qc.cdl
+++ b/cc_plugin_glider/tests/data/gliders/bad_qc.cdl
@@ -9,7 +9,7 @@ variables:
 		trajectory:long_name = "Trajectory/Deployment Name" ;
 	double time(time) ;
 		time:_FillValue = -999. ;
-		time:ancillary_variables = "time_qc" ;
+		time:ancillary_variables = "notavariable" ;
 		time:calendar = "gregorian" ;
 		time:long_name = "Time" ;
 		time:observation_type = "measured" ;

--- a/cc_plugin_glider/tests/data/gliders/no_qc.cdl
+++ b/cc_plugin_glider/tests/data/gliders/no_qc.cdl
@@ -8,7 +8,6 @@ variables:
         trajectory:comment = "A trajectory is a single deployment of a glider and may span multiple data files." ;
         trajectory:long_name = "Trajectory/Deployment Name" ;
     double time(time) ;
-        time:ancillary_variables = "time_qc" ;
         time:calendar = "gregorian" ;
         time:comment = "Measured or calculated time at each point in the time-series" ;
         time:long_name = "Time" ;
@@ -17,7 +16,6 @@ variables:
         time:units = "seconds since 1970-01-01T00:00:00Z" ;
     double lat(time) ;
         lat:_FillValue = -999. ;
-        lat:ancillary_variables = "qartod_location_flag lat_qc" ;
         lat:comment = "Interpolated latitude at each point in the time-series" ;
         lat:coordinate_reference_frame = "urn:ogc:crs:EPSG::4326" ;
         lat:long_name = "Latitude" ;
@@ -30,7 +28,6 @@ variables:
         lat:valid_min = -90. ;
     double lon(time) ;
         lon:_FillValue = -999. ;
-        lon:ancillary_variables = "qartod_location_flag lon_qc" ;
         lon:comment = "Interpolated longitude at each point in the time-series." ;
         lon:coordinate_reference_frame = "urn:ogc:crs:EPSG::4326" ;
         lon:long_name = "Longitude" ;
@@ -44,7 +41,6 @@ variables:
     double pressure(time) ;
         pressure:_FillValue = -999. ;
         pressure:accuracy = " " ;
-        pressure:ancillary_variables = "qartod_monotonic_pressure_flag qartod_pressure_flat_line_flag qartod_pressure_gross_range_flag qartod_pressure_rate_of_change_flag qartod_pressure_spike_flag pressure_qc" ;
         pressure:comment = " " ;
         pressure:instrument = "instrument_ctd" ;
         pressure:long_name = "Pressure" ;
@@ -61,7 +57,6 @@ variables:
     double depth(time) ;
         depth:_FillValue = -999. ;
         depth:accuracy = " " ;
-        depth:ancillary_variables = "depth_qc" ;
         depth:comment = " " ;
         depth:instrument = "instrument_ctd" ;
         depth:long_name = "Depth" ;
@@ -78,7 +73,6 @@ variables:
     double temperature(time) ;
         temperature:_FillValue = -999. ;
         temperature:accuracy = " " ;
-        temperature:ancillary_variables = "qartod_temperature_climatological_flag qartod_temperature_flat_line_flag qartod_temperature_gross_range_flag qartod_temperature_rate_of_change_flag qartod_temperature_spike_flag temperature_qc" ;
         temperature:instrument = "instrument_ctd" ;
         temperature:long_name = "Temperature" ;
         temperature:observation_type = "measured" ;
@@ -92,7 +86,6 @@ variables:
     double conductivity(time) ;
         conductivity:_FillValue = -999. ;
         conductivity:accuracy = " " ;
-        conductivity:ancillary_variables = "qartod_conductivity_climatological_flag qartod_conductivity_flat_line_flag qartod_conductivity_gross_range_flag qartod_conductivity_rate_of_change_flag qartod_conductivity_spike_flag conductivity_qc" ;
         conductivity:instrument = "instrument_ctd" ;
         conductivity:long_name = "Conductivity" ;
         conductivity:observation_type = "measured" ;
@@ -106,7 +99,6 @@ variables:
     double salinity(time) ;
         salinity:_FillValue = -999. ;
         salinity:accuracy = " " ;
-        salinity:ancillary_variables = "qartod_salinity_climatological_flag qartod_salinity_flat_line_flag qartod_salinity_rate_of_change_flag qartod_salinity_spike_flag salinity_qc" ;
         salinity:instrument = "instrument_ctd" ;
         salinity:long_name = "Salinity" ;
         salinity:observation_type = "calculated" ;
@@ -120,7 +112,6 @@ variables:
     double density(time) ;
         density:_FillValue = -999. ;
         density:accuracy = " " ;
-        density:ancillary_variables = "qartod_density_climatological_flag qartod_density_flat_line_flag qartod_density_rate_of_change_flag qartod_density_spike_flag density_qc" ;
         density:instrument = "instrument_ctd" ;
         density:long_name = "Density" ;
         density:observation_type = "calculated" ;

--- a/cc_plugin_glider/tests/data/gliders/no_qc.cdl
+++ b/cc_plugin_glider/tests/data/gliders/no_qc.cdl
@@ -1,0 +1,274 @@
+netcdf IOOS_Glider_NetCDF_v3.0-qartod {
+dimensions:
+    time = UNLIMITED ; // (0 currently)
+    traj_strlen = 20 ;
+variables:
+    char trajectory(traj_strlen) ;
+        trajectory:cf_role = "trajectory_id" ;
+        trajectory:comment = "A trajectory is a single deployment of a glider and may span multiple data files." ;
+        trajectory:long_name = "Trajectory/Deployment Name" ;
+    double time(time) ;
+        time:ancillary_variables = "time_qc" ;
+        time:calendar = "gregorian" ;
+        time:comment = "Measured or calculated time at each point in the time-series" ;
+        time:long_name = "Time" ;
+        time:observation_type = "measured" ;
+        time:standard_name = "time" ;
+        time:units = "seconds since 1970-01-01T00:00:00Z" ;
+    double lat(time) ;
+        lat:_FillValue = -999. ;
+        lat:ancillary_variables = "qartod_location_flag lat_qc" ;
+        lat:comment = "Interpolated latitude at each point in the time-series" ;
+        lat:coordinate_reference_frame = "urn:ogc:crs:EPSG::4326" ;
+        lat:long_name = "Latitude" ;
+        lat:observation_type = "measured" ;
+        lat:platform = "platform" ;
+        lat:reference = "WGS84" ;
+        lat:standard_name = "latitude" ;
+        lat:units = "degrees_north" ;
+        lat:valid_max = 90. ;
+        lat:valid_min = -90. ;
+    double lon(time) ;
+        lon:_FillValue = -999. ;
+        lon:ancillary_variables = "qartod_location_flag lon_qc" ;
+        lon:comment = "Interpolated longitude at each point in the time-series." ;
+        lon:coordinate_reference_frame = "urn:ogc:crs:EPSG::4326" ;
+        lon:long_name = "Longitude" ;
+        lon:observation_type = "measured" ;
+        lon:platform = "platform" ;
+        lon:reference = "WGS84" ;
+        lon:standard_name = "longitude" ;
+        lon:units = "degrees_east" ;
+        lon:valid_max = 180. ;
+        lon:valid_min = -180. ;
+    double pressure(time) ;
+        pressure:_FillValue = -999. ;
+        pressure:accuracy = " " ;
+        pressure:ancillary_variables = "qartod_monotonic_pressure_flag qartod_pressure_flat_line_flag qartod_pressure_gross_range_flag qartod_pressure_rate_of_change_flag qartod_pressure_spike_flag pressure_qc" ;
+        pressure:comment = " " ;
+        pressure:instrument = "instrument_ctd" ;
+        pressure:long_name = "Pressure" ;
+        pressure:observation_type = "measured" ;
+        pressure:platform = "platform" ;
+        pressure:positive = "down" ;
+        pressure:precision = " " ;
+        pressure:reference_datum = "sea-surface" ;
+        pressure:resolution = " " ;
+        pressure:standard_name = "sea_water_pressure" ;
+        pressure:units = "dbar" ;
+        pressure:valid_max = 2000. ;
+        pressure:valid_min = 0. ;
+    double depth(time) ;
+        depth:_FillValue = -999. ;
+        depth:accuracy = " " ;
+        depth:ancillary_variables = "depth_qc" ;
+        depth:comment = " " ;
+        depth:instrument = "instrument_ctd" ;
+        depth:long_name = "Depth" ;
+        depth:observation_type = "calculated" ;
+        depth:platform = "platform" ;
+        depth:positive = "down" ;
+        depth:precision = " " ;
+        depth:reference_datum = "sea-surface" ;
+        depth:resolution = " " ;
+        depth:standard_name = "depth" ;
+        depth:units = "m" ;
+        depth:valid_max = 2000. ;
+        depth:valid_min = 0. ;
+    double temperature(time) ;
+        temperature:_FillValue = -999. ;
+        temperature:accuracy = " " ;
+        temperature:ancillary_variables = "qartod_temperature_climatological_flag qartod_temperature_flat_line_flag qartod_temperature_gross_range_flag qartod_temperature_rate_of_change_flag qartod_temperature_spike_flag temperature_qc" ;
+        temperature:instrument = "instrument_ctd" ;
+        temperature:long_name = "Temperature" ;
+        temperature:observation_type = "measured" ;
+        temperature:platform = "platform" ;
+        temperature:precision = " " ;
+        temperature:resolution = " " ;
+        temperature:standard_name = "sea_water_temperature" ;
+        temperature:units = "Celsius" ;
+        temperature:valid_max = 40. ;
+        temperature:valid_min = -5. ;
+    double conductivity(time) ;
+        conductivity:_FillValue = -999. ;
+        conductivity:accuracy = " " ;
+        conductivity:ancillary_variables = "qartod_conductivity_climatological_flag qartod_conductivity_flat_line_flag qartod_conductivity_gross_range_flag qartod_conductivity_rate_of_change_flag qartod_conductivity_spike_flag conductivity_qc" ;
+        conductivity:instrument = "instrument_ctd" ;
+        conductivity:long_name = "Conductivity" ;
+        conductivity:observation_type = "measured" ;
+        conductivity:platform = "platform" ;
+        conductivity:precision = " " ;
+        conductivity:resolution = " " ;
+        conductivity:standard_name = "sea_water_electrical_conductivity" ;
+        conductivity:units = "S m-1" ;
+        conductivity:valid_max = 10. ;
+        conductivity:valid_min = 0. ;
+    double salinity(time) ;
+        salinity:_FillValue = -999. ;
+        salinity:accuracy = " " ;
+        salinity:ancillary_variables = "qartod_salinity_climatological_flag qartod_salinity_flat_line_flag qartod_salinity_rate_of_change_flag qartod_salinity_spike_flag salinity_qc" ;
+        salinity:instrument = "instrument_ctd" ;
+        salinity:long_name = "Salinity" ;
+        salinity:observation_type = "calculated" ;
+        salinity:platform = "platform" ;
+        salinity:precision = " " ;
+        salinity:resolution = " " ;
+        salinity:standard_name = "sea_water_practical_salinity" ;
+        salinity:units = 1 ;
+        salinity:valid_max = 40. ;
+        salinity:valid_min = 0. ;
+    double density(time) ;
+        density:_FillValue = -999. ;
+        density:accuracy = " " ;
+        density:ancillary_variables = "qartod_density_climatological_flag qartod_density_flat_line_flag qartod_density_rate_of_change_flag qartod_density_spike_flag density_qc" ;
+        density:instrument = "instrument_ctd" ;
+        density:long_name = "Density" ;
+        density:observation_type = "calculated" ;
+        density:platform = "platform" ;
+        density:precision = " " ;
+        density:resolution = " " ;
+        density:standard_name = "sea_water_density" ;
+        density:units = "kg m-3" ;
+        density:valid_max = 1040. ;
+        density:valid_min = 1015. ;
+    int profile_id ;
+        profile_id:_FillValue = -999 ;
+        profile_id:comment = "Sequential profile number within the trajectory.  This value is unique in each file that is part of a single trajectory/deployment." ;
+        profile_id:long_name = "Profile ID" ;
+        profile_id:valid_max = 2147483647 ;
+        profile_id:valid_min = 1 ;
+    double profile_time ;
+        profile_time:_FillValue = -999. ;
+        profile_time:calendar = "gregorian" ;
+        profile_time:comment = "Timestamp corresponding to the mid-point of the profile" ;
+        profile_time:long_name = "Profile Center Time" ;
+        profile_time:observation_type = "calculated" ;
+        profile_time:platform = "platform" ;
+        profile_time:standard_name = "time" ;
+        profile_time:units = "seconds since 1970-01-01T00:00:00Z" ;
+    double profile_lat ;
+        profile_lat:_FillValue = -999. ;
+        profile_lat:comment = "Value is interpolated to provide an estimate of the latitude at the mid-point of the profile" ;
+        profile_lat:long_name = "Profile Center Latitude" ;
+        profile_lat:observation_type = "calculated" ;
+        profile_lat:platform = "platform" ;
+        profile_lat:standard_name = "latitude" ;
+        profile_lat:units = "degrees_north" ;
+        profile_lat:valid_max = 90. ;
+        profile_lat:valid_min = -90. ;
+    double profile_lon ;
+        profile_lon:_FillValue = -999. ;
+        profile_lon:comment = "Value is interpolated to provide an estimate of the longitude at the mid-point of the profile" ;
+        profile_lon:long_name = "Profile Center Longitude" ;
+        profile_lon:observation_type = "calculated" ;
+        profile_lon:platform = "platform" ;
+        profile_lon:standard_name = "longitude" ;
+        profile_lon:units = "degrees_east" ;
+        profile_lon:valid_max = 180. ;
+        profile_lon:valid_min = -180. ;
+    double time_uv ;
+        time_uv:_FillValue = -999. ;
+        time_uv:calendar = "gregorian" ;
+        time_uv:comment = "The depth-averaged current is an estimate of the net current measured while the glider is underwater.  The value is calculated over the entire underwater segment, which may consist of 1 or more dives." ;
+        time_uv:long_name = "Depth-Averaged Time" ;
+        time_uv:observation_type = "calculated" ;
+        time_uv:standard_name = "time" ;
+        time_uv:units = "seconds since 1970-01-01T00:00:00Z" ;
+    double lat_uv ;
+        lat_uv:_FillValue = -999. ;
+        lat_uv:comment = "The depth-averaged current is an estimate of the net current measured while the glider is underwater.  The value is calculated over the entire underwater segment, which may consist of 1 or more dives." ;
+        lat_uv:long_name = "Depth-Averaged Latitude" ;
+        lat_uv:observation_type = "calculated" ;
+        lat_uv:platform = "platform" ;
+        lat_uv:standard_name = "latitude" ;
+        lat_uv:units = "degrees_north" ;
+        lat_uv:valid_max = 90. ;
+        lat_uv:valid_min = -90. ;
+    double lon_uv ;
+        lon_uv:_FillValue = -999. ;
+        lon_uv:comment = "The depth-averaged current is an estimate of the net current measured while the glider is underwater.  The value is calculated over the entire underwater segment, which may consist of 1 or more dives." ;
+        lon_uv:long_name = "Depth-Averaged Longitude" ;
+        lon_uv:observation_type = "calculated" ;
+        lon_uv:platform = "platform" ;
+        lon_uv:standard_name = "longitude" ;
+        lon_uv:units = "degrees_east" ;
+        lon_uv:valid_max = 180. ;
+        lon_uv:valid_min = -180. ;
+    double u ;
+        u:_FillValue = -999. ;
+        u:comment = "The depth-averaged current is an estimate of the net current measured while the glider is underwater.  The value is calculated over the entire underwater segment, which may consist of 1 or more dives." ;
+        u:long_name = "Depth-Averaged Eastward Sea Water Velocity" ;
+        u:observation_type = "calculated" ;
+        u:platform = "platform" ;
+        u:standard_name = "eastward_sea_water_velocity" ;
+        u:units = "m s-1" ;
+        u:valid_max = 10. ;
+        u:valid_min = -10. ;
+    double v ;
+        v:_FillValue = -999. ;
+        v:comment = "The depth-averaged current is an estimate of the net current measured while the glider is underwater.  The value is calculated over the entire underwater segment, which may consist of 1 or more dives." ;
+        v:long_name = "Depth-Averaged Northward Sea Water Velocity" ;
+        v:observation_type = "calculated" ;
+        v:platform = "platform" ;
+        v:standard_name = "northward_sea_water_velocity" ;
+        v:units = "m s-1" ;
+        v:valid_max = 10. ;
+        v:valid_min = -10. ;
+    int platform ;
+        platform:_FillValue = -999 ;
+        platform:comment = " " ;
+        platform:id = " " ;
+        platform:instrument = "instrument_ctd" ;
+        platform:long_name = " " ;
+        platform:type = "platform" ;
+        platform:wmo_id = " " ;
+    int instrument_ctd ;
+        instrument_ctd:_FillValue = -999 ;
+        instrument_ctd:calibration_date = " " ;
+        instrument_ctd:calibration_report = " " ;
+        instrument_ctd:comment = "pumped CTD" ;
+        instrument_ctd:factory_calibrated = " " ;
+        instrument_ctd:long_name = "Seabird Glider Payload CTD" ;
+        instrument_ctd:make_model = "Seabird GPCTD" ;
+        instrument_ctd:platform = "platform" ;
+        instrument_ctd:serial_number = " " ;
+        instrument_ctd:type = "platform" ;
+
+// global attributes:
+        :Conventions = "CF-1.6, Unidata Dataset Discovery v1.0" ;
+        :Metadata_Conventions = "CF-1.6, Unidata Dataset Discovery v1.0" ;
+        :acknowledgement = "This deployment supported by ..." ;              // Free-text attribution
+        :comment = "comment goes here" ;                                     // Any additional notes you may have to describe the dataset
+        :contributor_name = "luke" ;                                         // Comma-separated list of contirbutor names
+        :contributor_role = "imaginer" ;                                     // Comma-separated list of roles for each contributor listed in contributor_names
+        :creator_email = "luke@domain.com" ;                                 // E-Mail address of the creator responsible for the dataset
+        :creator_name = "Luke" ;                                             // Name of the creator
+        :creator_url = "http://luke.com" ;                                   // The URL of the person (or other creator type specified by the creator_type attribute) principally responsible for creating this data. 
+        :date_created = "2017-02-01" ;                                       // ISO-8601 Date string for when the dataset was created
+        :date_issued = "2017-02-01" ;                                        // ISO-8601 Date string for when the dataset was issued
+        :date_modified = "2017-02-01" ;                                      // ISO-8601 Date string for when the dataset was last modified
+        :format_version = "IOOS_Glider_NetCDF_v3.0-qartod" ;
+        :history = "2017-02-01T14:45-5 Created file " ;                      // List of strings describing historical modifications ot the dataset
+        :id = "example-20170201T1445" ;                                      // GliderDAC Deployment Identifier, e.g. ru29-20150318T0312
+        :institution = "RPS" ;                                               // Institution responsible for this dataset
+        :ioos_regional_association = "FakeOOS" ;                             // IOOS Regional Association that is associated with this dataset
+        :keywords = "AUVS > Autonomous Underwater Vehicles, Oceans > Ocean Pressure > Water Pressure, Oceans > Ocean Temperature > Water Temperature, Oceans > Salinity/Density > Conductivity, Oceans > Salinity/Density > Density, Oceans > Salinity/Density > Salinity" ;
+        :keywords_vocabulary = "GCMD Science Keywords" ;
+        :license = "This data may be redistributed and used without restriction.  Data provided as is with no expressed or implied assurance of quality assurance or quality control" ; // Provide the URL to a standard or specific license, enter "Freely Distributed" or "None", or describe any restrictions to data access and distribution in free text.
+        :metadata_link = "https://github.com/ioos/ioosngdac/" ;              // Link to the Metadata specification for GliderDAC
+        :naming_authority = "gov.noaa.ioos" ;                                // The organization that provides the initial id (see above) for the dataset. The naming authority should be uniquely specified by this attribute. We recommend using reverse-DNS naming for the naming authority; URIs are also acceptable. Example: 'edu.ucar.unidata'.
+        :platform_type = "Slocum Glider" ;                                   // Type of glider used to make collections
+        :processing_level = "observations" ;
+        :project = "Compliance Checker" ;                                    // Project the collection was a part of
+        :publisher_email = "luke@domain.com" ;                               // The email address of the person (or other entity specified by the publisher_type attribute) responsible for publishing the data file or product to users, with its current metadata and format.
+        :publisher_name = "Luke" ;                                           // The name of the person (or other entity specified by the publisher_type attribute) responsible for publishing the data file or product to users, with its current metadata and format.
+        :publisher_url = "http://fakeoos.com/" ;                             // The URL of the person (or other entity specified by the publisher_type attribute) responsible for publishing the data file or product to users, with its current metadata and format.
+        :references = "https://ioos.noaa.gov/wp-content/uploads/2015/10/Manual-for-QC-of-Glider-Data_05_09_16.pdf" ;
+        :sea_name = "Atlantic Ocean" ;                                       // The name of the sea in which the data were collected. See https://www.nodc.noaa.gov/General/NODC-Archive/seanamelist.txt for a list of NCEI sea names
+        :source = "Observational data from a profiling glider" ;             // The method of production of the original data. If it was model-generated, source should name the model and its version. If it is observational, source should characterize it. This attribute is defined in the CF Conventions. Examples: 'temperature from CTD #1234'; 'world model v.0.1'.
+        :standard_name_vocabulary = "CF-v37" ;                               // CF Standard Name table used for this dataset. http://cfconventions.org/documents.html contains a list of table versions.
+        :summary = "Example CDL file for compliance checker" ;               // A paragraph describing the dataset, analogous to an abstract for a paper.
+        :title = "Example Deployment" ;                                      // GliderDAC Deployment Identifier
+        :wmo_id = "" ;                                                       // WMO Identifier assigned by the WMO office.
+}
+

--- a/cc_plugin_glider/tests/resources.py
+++ b/cc_plugin_glider/tests/resources.py
@@ -28,5 +28,6 @@ STATIC_FILES = {
     'glider_std': get_filename('tests/data/gliders/IOOS_Glider_NetCDF_v2.0.cdl'),
     'glider_std3': get_filename('tests/data/gliders/IOOS_Glider_NetCDF_v3.0.cdl'),
     'bad_location': get_filename('tests/data/gliders/bad_location.cdl'),
-    'bad_qc': get_filename('tests/data/gliders/bad_qc.cdl')
+    'bad_qc': get_filename('tests/data/gliders/bad_qc.cdl'),
+    'no_qc': get_filename('tests/data/gliders/no_qc.cdl')
 }

--- a/cc_plugin_glider/tests/test_glidercheck.py
+++ b/cc_plugin_glider/tests/test_glidercheck.py
@@ -170,6 +170,18 @@ class TestGliderCheck(unittest.TestCase):
         result = self.check.check_qc_variables(dataset)
         assert result is None
 
+    def test_time_series_variables(self):
+        dataset = self.get_dataset(STATIC_FILES['bad_qc'])
+        result = self.check.check_time_series_variables(dataset)
+        assert result.value == (7, 8)
+        assert sorted(result.msgs) == [
+            'Invalid ancillary_variables attribute for time, notavariable is not a variable'
+        ]
+
+        dataset = self.get_dataset(STATIC_FILES['no_qc'])
+        result = self.check.check_time_series_variables(dataset)
+        assert result.value == (7, 7)
+
     def test_seanames(self):
         '''
         Tests that sea names error message appears

--- a/cc_plugin_glider/tests/test_glidercheck.py
+++ b/cc_plugin_glider/tests/test_glidercheck.py
@@ -147,6 +147,29 @@ class TestGliderCheck(unittest.TestCase):
         result = self.check.check_valid_max_dtype(dataset)
         assert result.value == (58, 58)
 
+    def test_qc_variables(self):
+        dataset = self.get_dataset(STATIC_FILES['glider_std'])
+        result = self.check.check_qc_variables(dataset)
+        assert result.value == (96, 96)
+
+        dataset = self.get_dataset(STATIC_FILES['glider_std3'])
+        result = self.check.check_qc_variables(dataset)
+        assert result.value == (96, 96)
+
+        dataset = self.get_dataset(STATIC_FILES['bad_qc'])
+        result = self.check.check_qc_variables(dataset)
+        assert result.value == (86, 90)
+        assert sorted(result.msgs) == [
+            'variable depth_qc must have a flag_meanings attribute',
+            'variable depth_qc must have a flag_values attribute',
+            'variable pressure_qc must have a long_name attribute',
+            'variable pressure_qc must have a standard_name attribute'
+        ]
+
+        dataset = self.get_dataset(STATIC_FILES['no_qc'])
+        result = self.check.check_qc_variables(dataset)
+        assert result is None
+
     def test_seanames(self):
         '''
         Tests that sea names error message appears
@@ -156,4 +179,3 @@ class TestGliderCheck(unittest.TestCase):
         self.assertEqual(result.value, (41, 64))
         self.assertIn(('sea_name attribute should be from the NODC sea names list:'
                        '   is not a valid sea name'), result.msgs)
-


### PR DESCRIPTION
I believe as of V3 that these `*_qc` variables are optional. I'm about to start uploading new files to the GliderDAC without the `*_qc` variables and the CC check was failing due to the missing variables.

Is this correct? Should we make a `gliderdac_v2` and `gliderdac_v3` checker to make these checks backwards compatible?