### PR TITLE
Updates to support acoustic datasets

### DIFF
--- a/cc_plugin_glider/glider_dac.py
+++ b/cc_plugin_glider/glider_dac.py
@@ -199,7 +199,7 @@ class GliderCheck(BaseNCCheck):
             test = dimension in dataset.dimensions
             score += int(test)
             if not test:
-                messages.append("%s is not a valid dimension" % dimension)
+                messages.append(f"{dimension} is not a valid dimension")
         return self.make_result(level, score, out_of, "Required Dimensions", messages)
 
     def check_lat_lon_attributes(self, dataset):
@@ -362,7 +362,7 @@ class GliderCheck(BaseNCCheck):
             score += int(test)
             out_of += 1
             if not test:
-                messages.append("Attr %s not present" % field)
+                messages.append(f"Attr {field} not present")
                 continue
             v = getattr(dataset, field, "")
             if isinstance(v, str):
@@ -372,7 +372,7 @@ class GliderCheck(BaseNCCheck):
             score += int(test)
             out_of += 1
             if not test:
-                messages.append("Attr %s is empty" % field)
+                messages.append(f"Attr {field} is empty")
 
         """
         Verify that sea_name attribute exists and is valid
@@ -456,7 +456,7 @@ class GliderCheck(BaseNCCheck):
         """
         # shouldn't this already be handled by CF trajectory featureType?
         test_ctx = TestCtx(BaseCheck.HIGH, "Profile data is valid")
-        if 'acoustic_profile_slocum' in self.options:
+        if not self.options is None and 'acoustic_profile_slocum' in self.options:
             # For the acoustic profiles, data is 3D data(time, depth).  Time
             # is repeated for n depths, but it still should be monotonically
             # increasing along unique records.
@@ -659,31 +659,24 @@ class GliderCheck(BaseNCCheck):
 
                 test_ctx.assert_true(
                     getattr(ncvar, "long_name", ""),
-                    "attribute {}:long_name must be a non-empty string".format(
-                        qartod_var,
-                    ),
+                    f"attribute {qartod_var}:long_name must be a non-empty string",
                 )
 
                 test_ctx.assert_true(
                     getattr(ncvar, "flag_meanings", ""),
-                    "attribute {}:flag_meanings must be a non-empty string".format(
-                        qartod_var,
-                    ),
+                    f"attribute {qartod_var}:flag_meanings must be a non-empty string",
                 )
 
                 test_ctx.assert_true(
                     isinstance(flag_values, np.ndarray),
-                    "attribute {}:flag_values must be defined as an array of bytes".format(
-                        qartod_var,
-                    ),
+                    f"attribute {qartod_var}:flag_values must be defined as an array of bytes",
                 )
 
                 if isinstance(flag_values, np.ndarray):
                     dtype = flag_values.dtype
                     test_ctx.assert_true(
                         util.compare_dtype(dtype, np.dtype("|i1")),
-                        "attribute {}:flag_values has an illegal data-type, must "
-                        "be byte".format(qartod_var),
+                        f"attribute {qartod_var}:flag_values has an illegal data-type, must be byte",
                     )
 
                 valid_min_dtype = getattr(valid_min, "dtype", None)
@@ -722,8 +715,7 @@ class GliderCheck(BaseNCCheck):
                     score += int(test)
                     if not test:
                         msg = (
-                            "Invalid ancillary_variables attribute for {}, "
-                            "{} is not a variable".format(var, acv)
+                            f"Invalid ancillary_variables attribute for {var}, {acv} is not a variable"
                         )
                         messages.append(msg)
 
@@ -775,8 +767,7 @@ class GliderCheck(BaseNCCheck):
             if valid_min is not None:
                 test_ctx.assert_true(
                     util.compare_dtype(np.dtype(valid_min_dtype), ncvar.dtype),
-                    "{}:valid_min has a different data type, {}, than variable {}, "
-                    "{}".format(var_name, valid_min_dtype, var_name, str(ncvar.dtype)),
+                    f"{var_name}:valid_min has a different data type, {valid_min_dtype}, than variable {var_name}, {str(ncvar.dtype)}"
                 )
 
         return test_ctx.to_result()
@@ -803,8 +794,7 @@ class GliderCheck(BaseNCCheck):
             if valid_max is not None:
                 test_ctx.assert_true(
                     util.compare_dtype(np.dtype(valid_max_dtype), ncvar.dtype),
-                    "{}:valid_max has a different data type, {}, than variable {} "
-                    "{}".format(var_name, valid_max_dtype, str(ncvar.dtype), var_name),
+                    f"{var_name}:valid_max has a different data type, {valid_max_dtype}, than variable {str(ncvar.dtype)} {var_name}"
                 )
 
         return test_ctx.to_result()
@@ -928,42 +918,27 @@ class GliderCheck(BaseNCCheck):
 
                 for var_name in var_name_set:
                     if var_name not in dataset.variables:
-                        msg = "Referenced {} variable {} does not exist".format(
-                            global_att_name,
-                            var_name,
-                        )
+                        msg = f"Referenced {global_att_name} variable {var_name} does not exist"
                         test_ctx.assert_true(False, msg)
                         continue
 
                     var = dataset.variables[var_name]
                     # have to use .ncattrs, hangs if using `in var` ?
                     var_attr_exists = var_remap[global_att_name] in var.ncattrs()
-                    msg = "Attribute {} should exist in variable {}".format(
-                        var_remap[global_att_name],
-                        var_name,
-                    )
+                    msg = f"Attribute {var_remap[global_att_name]} should exist in variable {var_name}"
                     test_ctx.assert_true(var_attr_exists, msg)
 
                     if not var_attr_exists:
                         continue
                     search_attr = getattr(var, var_remap[global_att_name])
 
-                    msg = "Attribute {} '{}' for variable {} not contained in {} authority table".format(
-                        var_remap[global_att_name],
-                        search_attr,
-                        var_name,
-                        global_att_name,
-                    )
+                    msg = f"Attribute {var_remap[global_att_name]} '{search_attr}' for variable {var_name} not contained in {global_att_name} authority table"
                     test_ctx.assert_true(search_attr in check_set, msg)
 
             else:
                 # check for global attribute existence already handled above
                 global_att_value = getattr(dataset, global_att_name)
-                msg = "Global attribute {} value '{}' not contained in {} authority table".format(
-                    global_att_name,
-                    global_att_value,
-                    global_att_name,
-                )
+                msg = f"Global attribute {global_att_name} value '{global_att_value}' not contained in {global_att_name} authority table"
                 test_ctx.assert_true(global_att_value in check_set, msg)
 
         return test_ctx.to_result()

--- a/cc_plugin_glider/glider_dac.py
+++ b/cc_plugin_glider/glider_dac.py
@@ -158,18 +158,6 @@ class GliderCheck(BaseNCCheck):
             "instrument_ctd",
         ]
 
-        if 'acoustic_profile_slocum' in self.options:
-            required_variables.remove('pressure')
-            required_variables.remove('temperature')
-            required_variables.remove('conductivity')
-            required_variables.remove('density')
-
-        if 'acoustic_metrics_slocum' in self.options:
-            required_variables.remove('depth')
-            required_variables.remove('u')
-            required_variables.remove('v')
-            required_variables.remove('instrument_ctd')
-
         level = BaseCheck.HIGH
         out_of = len(required_variables)
         score = 0
@@ -456,19 +444,10 @@ class GliderCheck(BaseNCCheck):
         """
         # shouldn't this already be handled by CF trajectory featureType?
         test_ctx = TestCtx(BaseCheck.HIGH, "Profile data is valid")
-        if not self.options is None and 'acoustic_profile_slocum' in self.options:
-            # For the acoustic profiles, data is 3D data(time, depth).  Time
-            # is repeated for n depths, but it still should be monotonically
-            # increasing along unique records.
-            test_ctx.assert_true(
-                np.all(np.diff(np.unique(ds.variables["time"])) > 0),
-                "Time variable is not monotonically increasing",
-            )
-        else:
-            test_ctx.assert_true(
-                np.all(np.diff(ds.variables["time"]) > 0),
-                "Time variable is not monotonically increasing",
-            )
+        test_ctx.assert_true(
+            np.all(np.diff(ds.variables["time"]) > 0),
+            "Time variable is not monotonically increasing",
+        )
         return test_ctx.to_result()
 
     def check_dim_no_data(self, dataset):

--- a/cc_plugin_glider/glider_dac.py
+++ b/cc_plugin_glider/glider_dac.py
@@ -26,12 +26,14 @@ class GliderCheck(BaseNCCheck):
     _cc_spec_version = "3.0"
     _cc_checker_version = __version__
     _cc_url = (
-        "https://github.com/ioos/ioosngdac/wiki/NGDAC-NetCDF-File-Format-Version-2"
+        "https://ioos.github.io/glider-dac/ngdac-netcdf-file-format-version-2"
     )
     _cc_display_headers = {3: "Required", 2: "Recommended", 1: "Suggested"}
     acceptable_platform_types = {"Seaglider", "Spray Glider", "Slocum Glider"}
 
-    def __init__(self):
+    def __init__(self, options=None):
+        # Pass through testing options for gliderdac
+        self.options = options
         # try to get the sea names table
         ncei_base_table_url = "https://gliders.ioos.us/ncei_authority_tables/"
         # might refactor if the authority tables names change
@@ -156,6 +158,18 @@ class GliderCheck(BaseNCCheck):
             "instrument_ctd",
         ]
 
+        if 'acoustic_profile_slocum' in self.options:
+            required_variables.remove('pressure')
+            required_variables.remove('temperature')
+            required_variables.remove('conductivity')
+            required_variables.remove('density')
+
+        if 'acoustic_metrics_slocum' in self.options:
+            required_variables.remove('depth')
+            required_variables.remove('u')
+            required_variables.remove('v')
+            required_variables.remove('instrument_ctd')
+
         level = BaseCheck.HIGH
         out_of = len(required_variables)
         score = 0
@@ -201,7 +215,7 @@ class GliderCheck(BaseNCCheck):
 
         check_vars = ["lat", "lon"]
         for var in check_vars:
-            stat, num_checks, msgs = util._check_variable_attrs(dataset, var)
+            stat, num_checks, msgs = util._check_variable_attrs(dataset, var, options=self.options)
             score += int(stat)
             out_of += num_checks
             messages.extend(msgs)
@@ -236,7 +250,7 @@ class GliderCheck(BaseNCCheck):
 
         check_vars = ["pressure", "depth"]
         for var in check_vars:
-            stat, num_checks, msgs = util._check_variable_attrs(dataset, var)
+            stat, num_checks, msgs = util._check_variable_attrs(dataset, var, options=self.options)
             score += int(stat)
             out_of += num_checks
             messages.extend(msgs)
@@ -261,7 +275,7 @@ class GliderCheck(BaseNCCheck):
 
         check_vars = ["temperature", "conductivity", "salinity", "density"]
         for var in check_vars:
-            stat, num_checks, msgs = util._check_variable_attrs(dataset, var)
+            stat, num_checks, msgs = util._check_variable_attrs(dataset, var, options=self.options)
             score += int(stat)
             out_of += num_checks
             messages.extend(msgs)
@@ -289,7 +303,7 @@ class GliderCheck(BaseNCCheck):
             "v",
         ]
         for var in check_vars:
-            stat, num_checks, msgs = util._check_variable_attrs(dataset, var)
+            stat, num_checks, msgs = util._check_variable_attrs(dataset, var, options=self.options)
             score += int(stat)
             out_of += num_checks
             messages.extend(msgs)
@@ -442,10 +456,19 @@ class GliderCheck(BaseNCCheck):
         """
         # shouldn't this already be handled by CF trajectory featureType?
         test_ctx = TestCtx(BaseCheck.HIGH, "Profile data is valid")
-        test_ctx.assert_true(
-            np.all(np.diff(ds.variables["time"]) > 0),
-            "Time variable is not monotonically increasing",
-        )
+        if 'acoustic_profile_slocum' in self.options:
+            # For the acoustic profiles, data is 3D data(time, depth).  Time
+            # is repeated for n depths, but it still should be monotonically
+            # increasing along unique records.
+            test_ctx.assert_true(
+                np.all(np.diff(np.unique(ds.variables["time"])) > 0),
+                "Time variable is not monotonically increasing",
+            )
+        else:
+            test_ctx.assert_true(
+                np.all(np.diff(ds.variables["time"]) > 0),
+                "Time variable is not monotonically increasing",
+            )
         return test_ctx.to_result()
 
     def check_dim_no_data(self, dataset):
@@ -596,7 +619,7 @@ class GliderCheck(BaseNCCheck):
             "instrument_ctd",
         ]
         for var in check_vars:
-            stat, num_checks, msgs = util._check_variable_attrs(dataset, var)
+            stat, num_checks, msgs = util._check_variable_attrs(dataset, var, options=self.options)
             score += int(stat)
             out_of += num_checks
             messages.extend(msgs)
@@ -820,8 +843,18 @@ class GliderCheck(BaseNCCheck):
             return
 
         longitude = dataset.variables["lon"]
-        valid_min = longitude.valid_min
-        valid_max = longitude.valid_max
+        valid_min = getattr(longitude, "valid_min", None)
+        if valid_min is None:
+            test_ctx.assert_true(
+                False,
+                "valid_min attribute for longitude should be defined",
+            )
+        valid_max = getattr(longitude, "valid_max", None)
+        if valid_min is None:
+            test_ctx.assert_true(
+                False,
+                "valid_max attribute for longitude should be defined",
+            )
         test_ctx.assert_true(
             not (valid_min == -90 and valid_max == 90),
             "Longitude's valid_min and valid_max are [-90, 90], it's likely this was a mistake",

--- a/cc_plugin_glider/util.py
+++ b/cc_plugin_glider/util.py
@@ -40,7 +40,7 @@ def _check_dtype(dataset, var_name):
         if not compare_dtype(var.dtype, np.dtype(expected_dtype)):
             messages.append(
                 f"Variable {var_name} is expected to have a dtype of "
-                f"{var.dtype}, instead has a dtype of {expected_dtype}"
+                f"{expected_dtype}, instead has a dtype of {var.dtype}"
                 "",
             )
             score -= 1
@@ -57,7 +57,7 @@ def _check_dtype(dataset, var_name):
     return (score, out_of, messages)
 
 
-def _check_variable_attrs(dataset, var_name, required_attributes=None):
+def _check_variable_attrs(dataset, var_name, required_attributes=None, options=set()):
     """
     Convenience method to check a variable attributes based on the
     expected_vars dict
@@ -73,6 +73,8 @@ def _check_variable_attrs(dataset, var_name, required_attributes=None):
 
     # Get the expected attrs to check
     check_attrs = required_attributes or required_var_attrs.get(var_name, {})
+    if 'ancillary_variables' in check_attrs and 'no_ancillary_variables' in options:
+        del check_attrs['ancillary_variables']
     var_attrs = set(var.ncattrs())
     for attr in check_attrs:
         if attr == "dtype":

--- a/cc_plugin_glider/util.py
+++ b/cc_plugin_glider/util.py
@@ -73,9 +73,13 @@ def _check_variable_attrs(dataset, var_name, required_attributes=None, options=N
 
     # Get the expected attrs to check
     check_attrs = required_attributes or required_var_attrs.get(var_name, {})
-    if not options is None:
-        if 'ancillary_variables' in check_attrs and 'no_ancillary_variables' in options:
-            del check_attrs['ancillary_variables']
+    skip_attributes = _get_option('skip_attributes', options)
+
+    if skip_attributes is not None:
+        for attr in skip_attributes:
+            if attr in check_attrs:
+                del check_attrs[attr]
+
     var_attrs = set(var.ncattrs())
     for attr in check_attrs:
         if attr == "dtype":
@@ -128,3 +132,49 @@ def _check_variable_attrs(dataset, var_name, required_attributes=None, options=N
                 pass
 
     return (score, out_of, messages)
+
+def _have_option(needle, option_haystack):
+    """
+    Helper function to determine if a user requested a specific
+    option.
+
+    Returns: True if an option was present, otherwise False
+    """
+
+    # Do the quick short-circuit fast test
+    if needle in option_haystack:
+        return True
+
+    # There may be a more complex option argument passed
+    # skip_attribute:one,two,three
+    for straw in option_haystack:
+        if straw.startswith(needle):
+            return True
+
+    return False
+
+def _get_option(needle, option_haystack):
+    """
+    Helper function to retrieve a user requested a specific
+    option.
+
+    Returns:
+      if found a list():
+        [needle] or if skip_attributes:dis,and,dat => [dis, and, dat]
+      if not found, None
+    """
+
+    # Do the quick short-circuit tests first
+    if option_haystack is None:
+        return None
+
+    if needle in option_haystack:
+        return list(needle)
+
+    # There may be a more complex option argument passed
+    # skip_attribute:one,two,three
+    for straw in option_haystack:
+        if straw.startswith(needle):
+            return straw.split(":")[1].split(",")
+
+    return None

--- a/cc_plugin_glider/util.py
+++ b/cc_plugin_glider/util.py
@@ -57,7 +57,7 @@ def _check_dtype(dataset, var_name):
     return (score, out_of, messages)
 
 
-def _check_variable_attrs(dataset, var_name, required_attributes=None, options=set()):
+def _check_variable_attrs(dataset, var_name, required_attributes=None, options=None):
     """
     Convenience method to check a variable attributes based on the
     expected_vars dict
@@ -73,8 +73,9 @@ def _check_variable_attrs(dataset, var_name, required_attributes=None, options=s
 
     # Get the expected attrs to check
     check_attrs = required_attributes or required_var_attrs.get(var_name, {})
-    if 'ancillary_variables' in check_attrs and 'no_ancillary_variables' in options:
-        del check_attrs['ancillary_variables']
+    if not options is None:
+        if 'ancillary_variables' in check_attrs and 'no_ancillary_variables' in options:
+            del check_attrs['ancillary_variables']
     var_attrs = set(var.ncattrs())
     for attr in check_attrs:
         if attr == "dtype":
@@ -110,11 +111,7 @@ def _check_variable_attrs(dataset, var_name, required_attributes=None, options=s
                         score -= 1
                 else:
                     messages.append(
-                        "Variable {} attribute {} must be {}".format(
-                            var_name,
-                            attr,
-                            check_attrs[attr],
-                        ),
+                        f"Variable {var_name} attribute {attr} must be {check_attrs[attr]}"
                     )
                     score -= 1
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ write_to_template = "__version__ = '{version}'"
 tag_regex = "^(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$"
 
 [tool.ruff]
-select = [
+lint.select = [
     "A", # flake8-builtins
     "B", # flake8-bugbear
     "C4", # flake8-comprehensions


### PR DESCRIPTION
 * Update the URL to point to the current documentation
 * Allow `options` to pass from compliance checker into the plugin.
 * Add option to skip attribute check on variables for ancillary_variables
 * Migrate to f-string formatting as suggested by ruff