### PR TITLE
Fix cf import

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     - id: blackdoc
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.4.1
+  rev: v2.4.2
   hooks:
     - id: codespell
       exclude: >
@@ -35,19 +35,19 @@ repos:
     - id: add-trailing-comma
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.14.8
+  rev: v0.15.12
   hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]
     - id: ruff-format
 
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: v2.11.1
+  rev: v2.21.2
   hooks:
     - id: pyproject-fmt
 
 - repo: https://github.com/woodruffw/zizmor-pre-commit
-  rev: v1.18.0
+  rev: v1.24.1
   hooks:
     - id: zizmor
 

--- a/cc_plugin_glider/glider_dac.py
+++ b/cc_plugin_glider/glider_dac.py
@@ -7,14 +7,13 @@ https://ioos.github.io/glider-dac/
 
 import os
 import warnings
-from urllib.parse import urljoin
+from io import BytesIO
 
 import numpy as np
 import requests
 from compliance_checker import __version__
 from compliance_checker.base import BaseCheck, BaseNCCheck, Result, TestCtx
 from compliance_checker.cf.cf import CF1_6Check
-from io import BytesIO
 from lxml import etree
 from requests.exceptions import RequestException
 
@@ -45,16 +44,26 @@ class GliderCheck(BaseNCCheck):
             "project": "NODC PROJECT NAMES THESAURUS",
             "platform": "NODC PLATFORM NAMES THESAURUS",
             "instrument": "Provider Instruments",
-            "institution": "NODC COLLECTING INSTITUTION NAMES THESAURUS"
+            "institution": "NODC COLLECTING INSTITUTION NAMES THESAURUS",
         }
 
         xpath_selector_template = ".//gmd:MD_Keywords[gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString/text()='{}']/gmd:keyword/{}/text()"
-        namespaces = {"gco": "http://www.isotc211.org/2005/gco", "gmd": "http://www.isotc211.org/2005/gmd", "gmx": "http://www.isotc211.org/2005/gmx"}
+        namespaces = {
+            "gco": "http://www.isotc211.org/2005/gco",
+            "gmd": "http://www.isotc211.org/2005/gmd",
+            "gmx": "http://www.isotc211.org/2005/gmx",
+        }
         self.auth_tables = {}
         for global_att_name, text_content in table_type.items():
-            text_elem = "gco:CharacterString" if global_att_name == "instrument" else "gmx:Anchor"
-            self.auth_tables[global_att_name] = tree.xpath(xpath_selector_template.format(text_content, text_elem),
-                                                           namespaces=namespaces)
+            text_elem = (
+                "gco:CharacterString"
+                if global_att_name == "instrument"
+                else "gmx:Anchor"
+            )
+            self.auth_tables[global_att_name] = tree.xpath(
+                xpath_selector_template.format(text_content, text_elem),
+                namespaces=namespaces,
+            )
         # handle NCEI sea names table
         sea_names_url = "https://www.ncei.noaa.gov/data/oceans/ncei/vocabulary/seanames.xml"
 
@@ -785,7 +794,6 @@ class GliderCheck(BaseNCCheck):
                         util.compare_dtype(dtype, np.dtype("|i1")),
                         f"attribute {qartod_var}:flag_values has an illegal data-type, must be byte",
                     )
-
 
         if test_ctx.out_of == 0:
             return None

--- a/cc_plugin_glider/glider_dac.py
+++ b/cc_plugin_glider/glider_dac.py
@@ -13,7 +13,7 @@ import numpy as np
 import requests
 from compliance_checker import __version__
 from compliance_checker.base import BaseCheck, BaseNCCheck, Result, TestCtx
-from compliance_checker.cf.cf import CF1_6Check
+from compliance_checker.cf import CF1_6Check
 from lxml import etree
 from requests.exceptions import RequestException
 

--- a/cc_plugin_glider/tests/data/ncei_metadata.xml
+++ b/cc_plugin_glider/tests/data/ncei_metadata.xml
@@ -39054,4 +39054,3 @@ General Comments: Seaglider from Oregon State University."</gco:CharacterString>
     </gmi:MI_AcquisitionInformation>
   </gmi:acquisitionInformation>
 </gmi:MI_Metadata>
-

--- a/cc_plugin_glider/tests/test_glidercheck.py
+++ b/cc_plugin_glider/tests/test_glidercheck.py
@@ -4,7 +4,6 @@ cc_plugin_glider/tests/test_glidercheck.py
 
 import os
 import unittest
-from urllib.parse import urljoin
 
 import numpy as np
 import requests_mock
@@ -341,7 +340,9 @@ class TestGliderCheck(unittest.TestCase):
 
         mock_nc_file = MockTimeSeries()
         mock_nc_file.project = "Mid-Atlantic Regional Association Coastal Ocean Observing System (MARACOOS)"
-        mock_nc_file.institution = "National Oceanic and Atmospheric Administration"
+        mock_nc_file.institution = (
+            "National Oceanic and Atmospheric Administration"
+        )
         instrument_var = mock_nc_file.createVariable("instrument", "i", ())
         instrument_var.make_model = "sea-bird"
         mock_nc_file.variables["depth"].instrument = "instrument"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,10 @@ dynamic = [
   "dependencies",
   "version",
 ]
-
 urls.documentation = "http://ioos.github.io/compliance-checker/"
 urls.homepage = "https://github.com/ioos/cc-plugin-glider"
 urls.repository = "https://github.com/ioos/cc-plugin-glider"
-entry-points."compliance_checker.suites"."gliderdac" = "cc_plugin_glider.glider_dac:GliderCheck"
+entry-points."compliance_checker.suites".gliderdac = "cc_plugin_glider.glider_dac:GliderCheck"
 
 [tool.setuptools]
 packages = [
@@ -43,12 +42,10 @@ include-package-data = true
 license-files = [
   "LICENSE.txt",
 ]
-
-[tool.setuptools.dynamic]
-dependencies = { file = [
+dynamic.dependencies = { file = [
   "requirements.txt",
 ] }
-readme = { file = "README.md", content-type = "text/markdown" }
+dynamic.readme = { file = "README.md", content-type = "text/markdown" }
 
 [tool.setuptools_scm]
 write_to = "cc_plugin_glider/_version.py"
@@ -58,7 +55,6 @@ tag_regex = "^(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$"
 [tool.ruff]
 target-version = "py39"
 line-length = 79
-
 lint.select = [
   "A",   # flake8-builtins
   "B",   # flake8-bugbear
@@ -82,8 +78,8 @@ ignore = [
   "tests/*",
 ]
 
-[tool.pytest.ini_options]
-filterwarnings = [
+[tool.pytest]
+ini_options.filterwarnings = [
   "error:::cc-plugin-glider.*",
   "ignore::UserWarning",
   "ignore::RuntimeWarning",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest
 requests-mock>=1.5.2
+setuptools-scm


### PR DESCRIPTION
The actual fix is in the last commit. We simplified things in latest compliance-checker and cf imports should be only directly from the main module. This is backwards compatible and will work with all cc versions.